### PR TITLE
Adds “Create for Isaac Lab” import option to remove worldBody/floor and flatten link hierarchy

### DIFF
--- a/source/extensions/isaacsim.asset.importer.mjcf/bindings/BindingsMjcfPython.cpp
+++ b/source/extensions/isaacsim.asset.importer.mjcf/bindings/BindingsMjcfPython.cpp
@@ -129,7 +129,10 @@ PYBIND11_MODULE(_mjcf, m)
              [](ImportConfig& config, const std::string value) { config.instanceableMeshUsdPath = value; })
         .def("set_visualize_collision_geoms",
              [](ImportConfig& config, const bool value) { config.visualizeCollisionGeoms = value; })
-        .def("set_import_sites", [](ImportConfig& config, const bool value) { config.importSites = value; });
+        .def("set_import_sites",
+             [](ImportConfig& config, const bool value) { config.importSites = value; })
+        .def("set_isaaclab",
+             [](ImportConfig& config, const bool value) { config.isaaclab = value; });
 
     defineInterfaceClass<Mjcf>(m, "Mjcf", "acquire_mjcf_interface", "release_mjcf_interface")
         .def("create_asset_mjcf", wrapInterfaceFunction(&Mjcf::createAssetFromMJCF), py::arg("fileName"),

--- a/source/extensions/isaacsim.asset.importer.mjcf/docs/CHANGELOG.md
+++ b/source/extensions/isaacsim.asset.importer.mjcf/docs/CHANGELOG.md
@@ -1,8 +1,4 @@
 # Changelog
-## [2.3.7] - 2025-07-11
-### Fixed
-- Provides an option in UI to make a model Isaac Lab compatible.
-
 ## [2.3.6] - 2025-02-19
 ### Fixed
 - Relative path for sublayers

--- a/source/extensions/isaacsim.asset.importer.mjcf/docs/CHANGELOG.md
+++ b/source/extensions/isaacsim.asset.importer.mjcf/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [2.3.7] - 2025-07-11
+### Fixed
+- Provides an option in UI to make a model Isaac Lab compatible.
+
 ## [2.3.6] - 2025-02-19
 ### Fixed
 - Relative path for sublayers

--- a/source/extensions/isaacsim.asset.importer.mjcf/plugins/Mjcf.h
+++ b/source/extensions/isaacsim.asset.importer.mjcf/plugins/Mjcf.h
@@ -49,6 +49,7 @@ struct ImportConfig
     bool overrideInertia = false;
     bool visualizeCollisionGeoms = false;
     bool importSites = true;
+    bool isaaclab = false;
 
     bool makeInstanceable = false;
     std::string instanceableMeshUsdPath = "./instanceable_meshes.usd";

--- a/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
+++ b/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
@@ -280,10 +280,13 @@ bool MJCFImporter::AddPhysicsEntities(std::unordered_map<std::string, pxr::UsdSt
     std::string instanceableUSDPath = config.instanceableMeshUsdPath;
     for (int i = 0; i < (int)bodies.size(); i++)
     {
-        std::string rootArtPrimPath = rootPrimPath + "/" + SanitizeUsdName(bodies[i]->name);
-        pxr::UsdGeomXform rootArtPrim = pxr::UsdGeomXform::Define(stages["base_stage"], pxr::SdfPath(rootArtPrimPath));
+        // COMMENTED THIS
+        // std::string rootArtPrimPath = rootPrimPath + "/" + SanitizeUsdName(bodies[i]->name);
+        // pxr::UsdGeomXform rootArtPrim = pxr::UsdGeomXform::Define(stages["base_stage"], pxr::SdfPath(rootArtPrimPath));
 
         CreatePhysicsBodyAndJoint(
+            // COMMENTED THIS
+            // stages, bodies[i], rootPrimPath, rootPrimPath, trans, true, rootPrimPath, config, instanceableUSDPath);
             stages, bodies[i], rootPrimPath, rootArtPrimPath, trans, true, rootPrimPath, config, instanceableUSDPath);
     }
     {

--- a/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
+++ b/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
@@ -280,7 +280,6 @@ bool MJCFImporter::AddPhysicsEntities(std::unordered_map<std::string, pxr::UsdSt
     std::string instanceableUSDPath = config.instanceableMeshUsdPath;
     for (int i = 0; i < (int)bodies.size(); i++)
     {
-        // COMMENTED THIS
         if (!config.isaaclab)
         {
             std::string rootArtPrimPath = rootPrimPath + "/" + SanitizeUsdName(bodies[i]->name);

--- a/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
+++ b/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
@@ -281,21 +281,28 @@ bool MJCFImporter::AddPhysicsEntities(std::unordered_map<std::string, pxr::UsdSt
     for (int i = 0; i < (int)bodies.size(); i++)
     {
         // COMMENTED THIS
-        // std::string rootArtPrimPath = rootPrimPath + "/" + SanitizeUsdName(bodies[i]->name);
-        // pxr::UsdGeomXform rootArtPrim = pxr::UsdGeomXform::Define(stages["base_stage"], pxr::SdfPath(rootArtPrimPath));
-
-        CreatePhysicsBodyAndJoint(
-            // COMMENTED THIS
-            // stages, bodies[i], rootPrimPath, rootPrimPath, trans, true, rootPrimPath, config, instanceableUSDPath);
-            stages, bodies[i], rootPrimPath, rootArtPrimPath, trans, true, rootPrimPath, config, instanceableUSDPath);
+        if (!config.isaaclab)
+        {
+            std::string rootArtPrimPath = rootPrimPath + "/" + SanitizeUsdName(bodies[i]->name);
+            pxr::UsdGeomXform rootArtPrim = pxr::UsdGeomXform::Define(stages["base_stage"], pxr::SdfPath(rootArtPrimPath));
+            CreatePhysicsBodyAndJoint(
+                stages, bodies[i], rootPrimPath, rootArtPrimPath, trans, true, rootPrimPath, config, instanceableUSDPath);
+        }
+        else
+        {
+            CreatePhysicsBodyAndJoint(
+                stages, bodies[i], rootPrimPath, rootPrimPath, trans, true, rootPrimPath, config, instanceableUSDPath);
+        }
     }
     {
         pxr::UsdEditContext context(stages["stage"], stages["physics_stage"]->GetRootLayer());
         AddContactFilters(stages["stage"]);
         AddTendons(stages["stage"], rootPrimPath);
 
-        // COMMENTED THIS
-        // addWorldGeomsAndSites(stages, rootPrimPath, config, instanceableUSDPath);
+        if (!config.isaaclab)
+        {
+            addWorldGeomsAndSites(stages, rootPrimPath, config, instanceableUSDPath);
+        }
     }
     std::vector<JointDefinition> jointDefinitions = analyzeConstraints(equalityConnects);
     for (const auto& jointDef : jointDefinitions)

--- a/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
+++ b/source/extensions/isaacsim.asset.importer.mjcf/plugins/MjcfImporter.cpp
@@ -294,7 +294,8 @@ bool MJCFImporter::AddPhysicsEntities(std::unordered_map<std::string, pxr::UsdSt
         AddContactFilters(stages["stage"]);
         AddTendons(stages["stage"], rootPrimPath);
 
-        addWorldGeomsAndSites(stages, rootPrimPath, config, instanceableUSDPath);
+        // COMMENTED THIS
+        // addWorldGeomsAndSites(stages, rootPrimPath, config, instanceableUSDPath);
     }
     std::vector<JointDefinition> jointDefinitions = analyzeConstraints(equalityConnects);
     for (const auto& jointDef : jointDefinitions)

--- a/source/extensions/isaacsim.asset.importer.mjcf/python/scripts/extension.py
+++ b/source/extensions/isaacsim.asset.importer.mjcf/python/scripts/extension.py
@@ -128,6 +128,7 @@ class Extension(omni.ext.IExt):
         self._config.set_make_default_prim(True)
         self._config.set_create_physics_scene(True)
         self._config.set_import_sites(True)
+        self._config.set_isaaclab(False)
         self._config.set_visualize_collision_geoms(False)
 
     def build_ui(self):

--- a/source/extensions/isaacsim.asset.importer.mjcf/python/scripts/option_widget.py
+++ b/source/extensions/isaacsim.asset.importer.mjcf/python/scripts/option_widget.py
@@ -234,6 +234,12 @@ class OptionWidget:
                     default_val=True,
                     on_clicked_fn=lambda m, config=self._config: config.set_import_sites(m),
                 )
+                checkbox_builder(
+                    "Create for Isaac Lab",
+                    tooltip="If True, the structure of the USD will be Isaac Lab compatible.",
+                    default_val=False,
+                    on_clicked_fn=lambda m, config=self._config: config.set_isaaclab(m),
+                )
 
         option_frame("Model", build_model_content)
 


### PR DESCRIPTION
This PR adds a new “Create for Isaac Lab” checkbox to the MJCF import UI that, when enabled, omits the default worldBody prim (and any floor associated) and collapses the double-nested folders into a single layer. By default the importer behavior remains unchanged, but checking the new option produces a clean, single-level USD scene that will fixes the import of MJCF robot models for training purposes.

Fixes: https://github.com/isaac-sim/IsaacLab/issues/2147

| **Before** | **After** | **Checkbox** |
| ------ | ----- |  ----- |
| ![](https://github.com/user-attachments/assets/6a5e6748-fffb-4730-a6b6-0ee56ce6b3f5) |  ![](https://github.com/user-attachments/assets/7a7d6168-578b-4ef1-81da-36456f3c33df) | ![](https://github.com/user-attachments/assets/56005225-3fc8-49dd-9eaa-1eb1e2cb21fb) |

